### PR TITLE
Test scroll-restorer

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,5 +3,6 @@
   "env": {
     "browser": true,
     "node": true,
+    "jest": true
   }
 }

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 var debounce = require('debounce');
 var xtend = require('xtend');
+var getWindow = require('./util/get_window').getWindow;
 
 var removeListenerFunctions;
 
@@ -12,7 +13,7 @@ function end() {
 }
 
 function getSavedScroll(input) {
-  input = input || window.history;
+  input = input || getWindow().history;
   if (!input || !input.state) return;
   return input.state.scroll;
 }
@@ -21,17 +22,17 @@ function restoreScroll(input, attemptsRemaining) {
   attemptsRemaining = attemptsRemaining == null ? 5 : attemptsRemaining;
   var savedScroll = getSavedScroll(input);
   if (!savedScroll) return;
-  window.requestAnimationFrame(function() {
+  getWindow().requestAnimationFrame(function() {
     var savedX = savedScroll.x;
     var savedY = savedScroll.y;
     if (attemptsRemaining === 0) return;
-    var pageXOffset = window.pageXOffset;
-    var pageYOffset = window.pageYOffset;
+    var pageXOffset = getWindow().pageXOffset;
+    var pageYOffset = getWindow().pageYOffset;
     if (
-      savedY < window.document.body.scrollHeight &&
+      savedY < getWindow().document.body.scrollHeight &&
       (savedX !== pageXOffset || savedY !== pageYOffset)
     ) {
-      window.scrollTo(savedX, savedY);
+      getWindow().scrollTo(savedX, savedY);
     } else {
       restoreScroll(input, attemptsRemaining - 1);
     }
@@ -48,45 +49,49 @@ function start(options) {
   );
 
   var captureScroll = debounce(function() {
-    window.requestAnimationFrame(function() {
-      var x = window.pageXOffset;
-      var y = window.pageYOffset;
-      var historyState = window.history.state;
+    getWindow().requestAnimationFrame(function() {
+      var x = getWindow().pageXOffset;
+      var y = getWindow().pageYOffset;
+      var historyState = getWindow().history.state;
       var savedX = historyState && historyState.scroll && historyState.scroll.x;
       var savedY = historyState && historyState.scroll && historyState.scroll.y;
       if (savedX !== x || savedY !== y) {
         var nextHistoryState = xtend(historyState, {
           scroll: { x: x, y: y }
         });
-        window.history.replaceState(nextHistoryState, null, window.location);
+        getWindow().history.replaceState(
+          nextHistoryState,
+          null,
+          getWindow().location
+        );
       }
     });
   }, options.captureScrollDebounce);
 
   // cf. https://developers.google.com/web/updates/2015/09/history-api-scroll-restoration
-  if ('scrollRestoration' in window.history) {
-    window.history.scrollRestoration = 'manual';
+  if ('scrollRestoration' in getWindow().history) {
+    getWindow().history.scrollRestoration = 'manual';
   }
 
   // Scroll positions are saved into the history entry's state; then when that
   // the history changes (the popstate event), we try restoring any saved
   // scroll position.
 
-  window.addEventListener('scroll', captureScroll, { passive: true });
+  getWindow().addEventListener('scroll', captureScroll, { passive: true });
   if (options.autoRestore) {
-    window.addEventListener('popstate', restoreScroll);
+    getWindow().addEventListener('popstate', restoreScroll);
   }
 
   removeListenerFunctions = [
     function() {
-      window.removeEventListener('scroll', captureScroll, {
+      getWindow().removeEventListener('scroll', captureScroll, {
         passive: true
       });
     }
   ];
   if (options.autoRestore) {
     removeListenerFunctions.push(function() {
-      window.removeEventListener('popstate', restoreScroll);
+      getWindow().removeEventListener('popstate', restoreScroll);
     });
   }
 }

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function restoreScroll(input, attemptsRemaining) {
 function start(options) {
   options = xtend(
     {
-      autoRestore: false,
+      autoRestore: true,
       captureScrollDebounce: 50
     },
     options || {}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "format": "prettier --single-quote --write '{,test/**/}*.js'",
     "lint": "eslint .",
     "start-example-app": "webpack-dev-server --config ./example/webpack.config.js --content-base ./example",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -37,6 +37,7 @@
     "eslint": "^4.1.1",
     "eslint-plugin-react": "^7.1.0",
     "husky": "^0.14.1",
+    "jest": "^20.0.4",
     "lint-staged": "^4.0.0",
     "prettier": "^1.5.2",
     "prop-types": "^15.5.10",
@@ -45,6 +46,19 @@
     "react-router-dom": "^4.1.1",
     "webpack": "^3.0.0",
     "webpack-dev-server": "^2.5.0"
+  },
+  "jest": {
+    "coverageReporters": [
+      "json",
+      "lcov",
+      "text",
+      "html"
+    ],
+    "resetMocks": true,
+    "roots": [
+      "./test"
+    ],
+    "testRegex": ".*\\.test\\.js$"
   },
   "lint-staged": {
     "{,test/**/}*.js": [

--- a/test/get_window.test.js
+++ b/test/get_window.test.js
@@ -1,0 +1,7 @@
+var getWindowModule = require('../util/get_window');
+
+describe('get-window', function() {
+  it('returns the window object', function() {
+    expect(getWindowModule.getWindow()).toBe(window);
+  });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,224 @@
+jest.mock('../util/get_window');
+
+var getWindowModule = require('../util/get_window');
+var scrollRestorer = require('../index');
+
+describe('scroll-restorer', function() {
+  beforeEach(function() {
+    // Mock the window object.
+    jest.spyOn(getWindowModule, 'getWindow').mockReturnValue({
+      addEventListener: jest.fn(),
+      document: {
+        body: {
+          scrollHeight: 100
+        }
+      },
+      history: {
+        replaceState: jest.fn(),
+        scrollRestoration: 'foo',
+        state: {
+          scroll: {
+            x: 0,
+            y: 0
+          }
+        }
+      },
+      location: 'foo',
+      pageXOffset: 0,
+      pageYOffset: 0,
+      removeEventListener: jest.fn(),
+      replaceState: jest.fn(),
+      // We just invoke requestAnimationFrame functions immediately.
+      requestAnimationFrame: function(fn) {
+        fn();
+      },
+      scrollTo: jest.fn()
+    });
+  });
+
+  afterEach(function() {
+    getWindowModule.getWindow.mockRestore();
+  });
+
+  describe('start', function() {
+    it('adds a scroll event listener', function() {
+      scrollRestorer.start();
+      var addEventListenerArgs = getWindowModule.getWindow().addEventListener
+        .mock.calls[0];
+      expect(addEventListenerArgs[0]).toBe('scroll');
+    });
+
+    it('adds a scroll event listener with pasive option enabled', function() {
+      scrollRestorer.start();
+      var addEventListenerArgs = getWindowModule.getWindow().addEventListener
+        .mock.calls[0];
+      expect(addEventListenerArgs[2]).toEqual({ passive: true });
+    });
+
+    it('adds a popstate event listener when autoRestore is enabled', function() {
+      scrollRestorer.start({ autoRestore: true });
+      // We should have attached popstate and scroll event listeners.
+      expect(
+        getWindowModule.getWindow().addEventListener.mock.calls.length
+      ).toBe(2);
+      // The second call should be a popstate listener.
+      var addEventListenerArgs = getWindowModule.getWindow().addEventListener
+        .mock.calls[1];
+      expect(addEventListenerArgs[0]).toBe('popstate');
+    });
+
+    it('does not add a popstate event listener when autoRestore is omitted', function() {
+      scrollRestorer.start();
+      // We should have attached only a scroll listener.
+      expect(
+        getWindowModule.getWindow().addEventListener.mock.calls.length
+      ).toBe(1);
+      // We should not have attached a popstate listener.
+      var addEventListenerArgs = getWindowModule.getWindow().addEventListener
+        .mock.calls[0];
+      expect(addEventListenerArgs[0]).not.toBe('popstate');
+    });
+
+    it('sets history.scrollRestoration to manual', function() {
+      expect(getWindowModule.getWindow().history.scrollRestoration).toEqual(
+        'foo'
+      );
+      scrollRestorer.start();
+      expect(getWindowModule.getWindow().history.scrollRestoration).toEqual(
+        'manual'
+      );
+    });
+  });
+
+  describe('captureScroll', function() {
+    beforeEach(function() {
+      jest.useFakeTimers();
+    });
+
+    afterEach(function() {
+      jest.useRealTimers();
+    });
+
+    it('calls #replaceState if the saved offset values have changed', function() {
+      // We're pretending that the user scrolled the window by 20px on both axes.
+      getWindowModule.getWindow().pageXOffset = 20;
+      getWindowModule.getWindow().pageYOffset = 20;
+
+      scrollRestorer.start();
+      var addEventListenerArgs = getWindowModule.getWindow().addEventListener
+        .mock.calls[0];
+      // Let's verify that this is the scroll event listener.
+      expect(addEventListenerArgs[0]).toEqual('scroll');
+      // Let's invoke the debounced event handler directly.
+      addEventListenerArgs[1]();
+      // We fake the passage of time to invoke our debounced function.
+      jest.runAllTimers();
+      // Assert that replaceState was invoked with the "new" scroll offset values.
+      expect(
+        getWindowModule.getWindow().history.replaceState
+      ).toHaveBeenCalledWith(
+        { scroll: { x: 20, y: 20 } },
+        null,
+        getWindowModule.getWindow().location
+      );
+    });
+
+    it('does not call #replaceState if the saved offset values have not changed', function() {
+      scrollRestorer.start();
+      var addEventListenerArgs = getWindowModule.getWindow().addEventListener
+        .mock.calls[0];
+      // Let's verify that this is the scroll event listener.
+      expect(addEventListenerArgs[0]).toEqual('scroll');
+      // Let's invoke the debounced event handler directly.
+      addEventListenerArgs[1]();
+      // We fake the passage of time to invoke our debounced function.
+      jest.runAllTimers();
+      expect(
+        getWindowModule.getWindow().history.replaceState
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getSavedScroll', function() {
+    it('returns value from provided input', function() {
+      expect(scrollRestorer.getSavedScroll({ state: { scroll: 'foo' } })).toBe(
+        'foo'
+      );
+    });
+
+    it('returns value from window.history when input is not defined', function() {
+      expect(scrollRestorer.getSavedScroll()).toEqual({ x: 0, y: 0 });
+    });
+
+    it('returns undefined when input.state is undefined', function() {
+      expect(scrollRestorer.getSavedScroll({ foo: 'bar' })).toEqual(undefined);
+    });
+  });
+
+  describe('restoreScroll', function() {
+    it('calls #scrollTo with a position retrieved from state in window.history', function() {
+      // We're pretending that a scroll position has been saved previously.
+      getWindowModule.getWindow().history.state.scroll = { x: 0, y: 20 };
+
+      scrollRestorer.start();
+      scrollRestorer.restoreScroll();
+      scrollRestorer.end();
+
+      expect(getWindowModule.getWindow().scrollTo).toHaveBeenCalledWith(0, 20);
+    });
+
+    it('calls #scrollTo with a position retrieved from a popstate event', function() {
+      var popstateEvent = { state: { scroll: { x: 0, y: 40 } } };
+
+      scrollRestorer.start();
+      scrollRestorer.restoreScroll(popstateEvent);
+      scrollRestorer.end();
+
+      expect(getWindowModule.getWindow().scrollTo).toHaveBeenCalledWith(0, 40);
+    });
+
+    it('does not call #scrollTo when unnecessary', function() {
+      // We're pretending that the user scrolled the window by 20px on the y axis.
+      getWindowModule.getWindow().pageXOffset = 0;
+      getWindowModule.getWindow().pageYOffset = 20;
+      // We're pretending that the same scroll position has already been saved.
+      getWindowModule.getWindow().history.state.scroll = { x: 0, y: 20 };
+
+      scrollRestorer.start();
+      scrollRestorer.restoreScroll();
+      scrollRestorer.end();
+
+      expect(getWindowModule.getWindow().scrollTo).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('end', function() {
+    it('removes the scroll event listener with identical arguments', function() {
+      scrollRestorer.start();
+      scrollRestorer.end();
+      var addEventListenerArgs = getWindowModule.getWindow().addEventListener
+        .mock.calls[0];
+      var removeEventListenerArgs = getWindowModule.getWindow()
+        .removeEventListener.mock.calls[0];
+      // Let's verify that this is the scroll event listener.
+      expect(addEventListenerArgs[0]).toEqual('scroll');
+      // Let's verify that our handler function is === when adding and removing.
+      expect(addEventListenerArgs[1]).toBe(removeEventListenerArgs[1]);
+      expect(addEventListenerArgs).toEqual(removeEventListenerArgs);
+    });
+
+    it('removes the popstate event listener with identical arguments', function() {
+      scrollRestorer.start({ autoRestore: true });
+      scrollRestorer.end();
+      var addEventListenerArgs = getWindowModule.getWindow().addEventListener
+        .mock.calls[1];
+      var removeEventListenerArgs = getWindowModule.getWindow()
+        .removeEventListener.mock.calls[1];
+      // Let's verify that this is the popstate event listener.
+      expect(addEventListenerArgs[0]).toEqual('popstate');
+      // Let's verify that our handler function is === when adding and removing.
+      expect(addEventListenerArgs[1]).toBe(removeEventListenerArgs[1]);
+      expect(addEventListenerArgs).toEqual(removeEventListenerArgs);
+    });
+  });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -55,8 +55,8 @@ describe('scroll-restorer', function() {
       expect(addEventListenerArgs[2]).toEqual({ passive: true });
     });
 
-    it('adds a popstate event listener when autoRestore is enabled', function() {
-      scrollRestorer.start({ autoRestore: true });
+    it('adds a popstate event listener when autoRestore option is omitted', function() {
+      scrollRestorer.start();
       // We should have attached popstate and scroll event listeners.
       expect(
         getWindowModule.getWindow().addEventListener
@@ -70,8 +70,8 @@ describe('scroll-restorer', function() {
       expect(popStateListenerCall.length).toBe(1);
     });
 
-    it('does not add a popstate event listener when autoRestore is omitted', function() {
-      scrollRestorer.start();
+    it('does not add a popstate event listener when autoRestore option is false', function() {
+      scrollRestorer.start({ autoRestore: false });
       // We should have attached only a scroll listener.
       expect(
         getWindowModule.getWindow().addEventListener

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -79,13 +79,22 @@ describe('scroll-restorer', function() {
       expect(addEventListenerArgs[0]).not.toBe('popstate');
     });
 
-    it('sets history.scrollRestoration to manual', function() {
+    it('sets history.scrollRestoration to manual if property exists', function() {
       expect(getWindowModule.getWindow().history.scrollRestoration).toEqual(
         'foo'
       );
       scrollRestorer.start();
       expect(getWindowModule.getWindow().history.scrollRestoration).toEqual(
         'manual'
+      );
+    });
+
+    it('does not set history.scrollRestoration if property does not exists', function() {
+      delete getWindowModule.getWindow().history.scrollRestoration;
+
+      scrollRestorer.start();
+      expect(getWindowModule.getWindow().history.scrollRestoration).toEqual(
+        undefined
       );
     });
   });
@@ -159,20 +168,14 @@ describe('scroll-restorer', function() {
     it('calls #scrollTo with a position retrieved from state in window.history', function() {
       // We're pretending that a scroll position has been saved previously.
       getWindowModule.getWindow().history.state.scroll = { x: 0, y: 20 };
-
-      scrollRestorer.start();
       scrollRestorer.restoreScroll();
-      scrollRestorer.end();
 
       expect(getWindowModule.getWindow().scrollTo).toHaveBeenCalledWith(0, 20);
     });
 
     it('calls #scrollTo with a position retrieved from a popstate event', function() {
       var popstateEvent = { state: { scroll: { x: 0, y: 40 } } };
-
-      scrollRestorer.start();
       scrollRestorer.restoreScroll(popstateEvent);
-      scrollRestorer.end();
 
       expect(getWindowModule.getWindow().scrollTo).toHaveBeenCalledWith(0, 40);
     });
@@ -189,6 +192,14 @@ describe('scroll-restorer', function() {
       scrollRestorer.end();
 
       expect(getWindowModule.getWindow().scrollTo).not.toHaveBeenCalled();
+    });
+
+    it('returns early if no saved scroll positions exist', function() {
+      getWindowModule.getWindow().requestAnimationFrame = jest.fn();
+      scrollRestorer.restoreScroll({ foo: 'bar' });
+      expect(
+        getWindowModule.getWindow().requestAnimationFrame
+      ).not.toHaveBeenCalled();
     });
   });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -48,7 +48,7 @@ describe('scroll-restorer', function() {
       expect(addEventListenerArgs[0]).toBe('scroll');
     });
 
-    it('adds a scroll event listener with pasive option enabled', function() {
+    it('adds a scroll event listener with passive option enabled', function() {
       scrollRestorer.start();
       var addEventListenerArgs = getWindowModule.getWindow().addEventListener
         .mock.calls[0];
@@ -59,20 +59,23 @@ describe('scroll-restorer', function() {
       scrollRestorer.start({ autoRestore: true });
       // We should have attached popstate and scroll event listeners.
       expect(
-        getWindowModule.getWindow().addEventListener.mock.calls.length
-      ).toBe(2);
-      // The second call should be a popstate listener.
-      var addEventListenerArgs = getWindowModule.getWindow().addEventListener
-        .mock.calls[1];
-      expect(addEventListenerArgs[0]).toBe('popstate');
+        getWindowModule.getWindow().addEventListener
+      ).toHaveBeenCalledTimes(2);
+      // Find the popstate addEventListener call.
+      var popStateListenerCall = getWindowModule
+        .getWindow()
+        .addEventListener.mock.calls.filter(function(callArgs) {
+          return callArgs[0] === 'popstate';
+        });
+      expect(popStateListenerCall.length).toBe(1);
     });
 
     it('does not add a popstate event listener when autoRestore is omitted', function() {
       scrollRestorer.start();
       // We should have attached only a scroll listener.
       expect(
-        getWindowModule.getWindow().addEventListener.mock.calls.length
-      ).toBe(1);
+        getWindowModule.getWindow().addEventListener
+      ).toHaveBeenCalledTimes(1);
       // We should not have attached a popstate listener.
       var addEventListenerArgs = getWindowModule.getWindow().addEventListener
         .mock.calls[0];

--- a/util/get_window.js
+++ b/util/get_window.js
@@ -1,0 +1,6 @@
+// This makes window mockable in Jest tests
+function getWindow() {
+  return window;
+}
+
+module.exports = { getWindow: getWindow };


### PR DESCRIPTION
This PR tests the `scroll-restorer` module. In order to reliably mock various methods and properties on the `window` object, a `getWindow` module was introduced.